### PR TITLE
Convert to Typescript + update CSON grammar + add bootstrapping

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,42 @@
+# Javascript Node CircleCI 2.0 configuration file
+#
+# Check https://circleci.com/docs/2.0/language-javascript/ for more details
+#
+version: 2
+jobs:
+  build:
+    docker:
+      - image: circleci/node:10
+
+    working_directory: ~/repo
+
+    steps:
+      - checkout
+      - run:
+          name: "Pull Submodules"
+          command: |
+            git submodule init
+            git submodule update --remote
+
+      # Download and cache dependencies
+      - restore_cache:
+          keys:
+            - v1-dependencies-{{ checksum "package.json" }}
+            # fallback to using the latest cache if no exact match is found
+            - v1-dependencies-
+
+      # Install APM
+      #- run:
+      #    name: "Install package dependencies"
+      #    command: |
+      #      sudo apt-get update && sudo apt-get install -y libsecret-1-dev
+      #      npm install atom-package-manager
+
+      - run: npm install
+
+      - save_cache:
+          paths:
+            - node_modules
+          key: v1-dependencies-{{ checksum "package.json" }}
+
+      - run: npx tsc

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 *.log
 node_modules
 /out
+/venv

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.log
 node_modules
+/out

--- a/grammars/storyscript.cson
+++ b/grammars/storyscript.cson
@@ -1,1 +1,515 @@
-../syntax-highlighter/dist/atom/grammars/storyscript.cson
+fileTypes: [
+  "story"
+  "storyscript"
+]
+name: "Storyscript"
+patterns: [
+  {
+    include: "#main"
+  }
+]
+scopeName: "source.story"
+uuid: "DB4E14AE-D10C-4B28-A55E-7C895B402701"
+repository:
+  main:
+    patterns: [
+      {
+        include: "#multi_line_comment"
+      }
+      {
+        include: "#comment"
+      }
+      {
+        include: "#keyword"
+      }
+      {
+        include: "#assignment"
+      }
+      {
+        include: "#scope"
+      }
+      {
+        include: "#function"
+      }
+      {
+        include: "#something"
+      }
+    ]
+  arithmetic:
+    patterns: [
+      {
+        match: "(\\+|\\-|\\*|\\*\\*|/|//|%|<<|>>|&|\\||\\^|~|(?!^)@)"
+        name: "keyword.operator.arithmetic.Storyscript"
+      }
+    ]
+  assignment:
+    patterns: [
+      {
+        match: "(=)"
+        name: "keyword.operator.assignment.Storyscript"
+      }
+    ]
+  boolean:
+    patterns: [
+      {
+        match: "(true|false)"
+        name: "constant.other.Storyscript"
+      }
+    ]
+  colon:
+    patterns: [
+      {
+        match: "(\\:)"
+        name: "constant.character.punctuation.Storyscript"
+      }
+    ]
+  comma:
+    patterns: [
+      {
+        match: "(\\,)"
+        name: "constant.character.punctuation.Storyscript"
+      }
+    ]
+  comment:
+    patterns: [
+      {
+        match: "(#.*)"
+        name: "comment.Storyscript"
+      }
+    ]
+  comparison:
+    patterns: [
+      {
+        match: "(<\\=|>\\=|\\=\\=|<|>|\\!\\=)"
+        name: "keyword.operator.comparison.Storyscript"
+      }
+    ]
+  function:
+    patterns: [
+      {
+        begin: "(function)"
+        beginCaptures:
+          "1":
+            name: "support.function.Storyscript"
+        contentName: "support.function.Storyscript"
+        end: "((?!function\\s*)\\w+)"
+        endCaptures:
+          "1":
+            name: "entity.name.function.Storyscript"
+      }
+    ]
+  function__1:
+    patterns: []
+  illegal:
+    patterns: [
+      {
+        match: "([^\\s])"
+        name: "invalid.Storyscript"
+      }
+    ]
+  keytype__1:
+    patterns: [
+      {
+        include: "#type"
+      }
+      {
+        match: "(:)"
+        name: "constant.character.punctuation.Storyscript"
+      }
+    ]
+  keyvalue:
+    patterns: [
+      {
+        begin: "([\\w_]+(?=\\s*:))"
+        beginCaptures:
+          "1":
+            name: "variable.parameter.Storyscript"
+        contentName: "variable.parameter.Storyscript"
+        end: "(:)"
+        endCaptures:
+          "1":
+            name: "constant.character.punctuation.Storyscript"
+      }
+    ]
+  keyvalue__1:
+    patterns: []
+  keyword:
+    patterns: [
+      {
+        match: "(break|as|catch|returns?|continue|else|finally|if|then|try|when|while|foreach|pass|import)"
+        name: "keyword.control.flow.Storyscript"
+      }
+    ]
+  list:
+    patterns: [
+      {
+        begin: "(\\[)"
+        beginCaptures:
+          "1":
+            name: "punctuation.definition.array.Storyscript"
+        patterns: [
+          {
+            include: "#list__1"
+          }
+        ]
+        end: "(\\])"
+        endCaptures:
+          "1":
+            name: "punctuation.definition.array.Storyscript"
+      }
+    ]
+  list__1:
+    patterns: [
+      {
+        include: "#comma"
+      }
+      {
+        include: "#something"
+      }
+    ]
+  map:
+    patterns: [
+      {
+        begin: "(\\{)"
+        beginCaptures:
+          "1":
+            name: "punctuation.definition.Storyscript"
+        patterns: [
+          {
+            include: "#map__1"
+          }
+        ]
+        end: "(\\})"
+        endCaptures:
+          "1":
+            name: "punctuation.definition.Storyscript"
+      }
+    ]
+  map__1:
+    patterns: [
+      {
+        include: "#mapassign"
+      }
+    ]
+  mapassign:
+    patterns: [
+      {
+        begin: "((?=[\\\"\\'][\\w_]+[\\\"\\']\\s*:\\s*))"
+        beginCaptures:
+          "1":
+            name: "meta.identifier.Storyscript"
+        patterns: [
+          {
+            include: "#mapassign__1"
+          }
+        ]
+        end: "((?=[\\,\\}]))"
+        endCaptures:
+          "1":
+            name: "meta.identifier.Storyscript"
+      }
+    ]
+  mapassign__1:
+    patterns: [
+      {
+        include: "#comma"
+      }
+      {
+        include: "#colon"
+      }
+      {
+        include: "#something"
+      }
+    ]
+  multi_line_comment:
+    patterns: [
+      {
+        begin: "(###)"
+        beginCaptures:
+          "1":
+            name: "comment.Storyscript"
+        contentName: "comment.Storyscript"
+        end: "(###[^\\n]*)"
+        endCaptures:
+          "1":
+            name: "comment.Storyscript"
+      }
+    ]
+  multi_line_comment__1:
+    patterns: []
+  null:
+    patterns: [
+      {
+        match: "(null)"
+        name: "support.constant.Storyscript"
+      }
+    ]
+  numeric:
+    patterns: [
+      {
+        match: "\\b((0([box])[0-9a-fA-F]+)|([0-9]+(\\.[0-9]+)?(e[\\x{002b}\\-]?[0-9]+)?))\\b"
+        name: "constant.numeric.Storyscript"
+      }
+    ]
+  placeholder:
+    patterns: [
+      {
+        begin: "(\\{\\s*)"
+        beginCaptures:
+          "1":
+            name: "string.punctuation.Storyscript"
+        patterns: [
+          {
+            include: "#placeholder__1"
+          }
+        ]
+        end: "(\\s*\\})"
+        endCaptures:
+          "1":
+            name: "string.punctuation.Storyscript"
+      }
+    ]
+  placeholder__1:
+    patterns: [
+      {
+        include: "#something"
+      }
+    ]
+  regexp:
+    patterns: [
+      {
+        match: "(\\/(?![\\s\\x{003d}\\x{002f}\\x{002a}\\x{002b}\\x{007b}\\x{007d}\\x{003f}])(\\\\.|.)*?/[igmy]{0,4}(?![a-zA-Z0-9]))"
+        name: "source.regexp.Storyscript"
+      }
+    ]
+  scope:
+    patterns: [
+      {
+        begin: "(\\()"
+        beginCaptures:
+          "1":
+            name: "constant.character.punctuation.Storyscript"
+        patterns: [
+          {
+            include: "#scope__1"
+          }
+        ]
+        end: "(\\))"
+        endCaptures:
+          "1":
+            name: "constant.character.punctuation.Storyscript"
+      }
+    ]
+  scope__1:
+    patterns: [
+      {
+        include: "#something"
+      }
+    ]
+  slug:
+    patterns: [
+      {
+        match: "([\\w_]+[\\w_-]*/[\\w_]+[\\w_-]*)"
+        name: "variable.other.Storyscript"
+      }
+    ]
+  something:
+    patterns: [
+      {
+        include: "#numeric"
+      }
+      {
+        include: "#string_single"
+      }
+      {
+        include: "#string_double"
+      }
+      {
+        include: "#string_single_triple"
+      }
+      {
+        include: "#string_double_triple"
+      }
+      {
+        include: "#map"
+      }
+      {
+        include: "#null"
+      }
+      {
+        include: "#list"
+      }
+      {
+        include: "#regexp"
+      }
+      {
+        include: "#boolean"
+      }
+      {
+        include: "#comment"
+      }
+      {
+        include: "#keyvalue"
+      }
+      {
+        include: "#slug"
+      }
+      {
+        include: "#variable"
+      }
+      {
+        include: "#varattr"
+      }
+      {
+        include: "#scope"
+      }
+      {
+        include: "#comparison"
+      }
+      {
+        include: "#arithmetic"
+      }
+      {
+        include: "#illegal"
+      }
+    ]
+  string_double:
+    patterns: [
+      {
+        begin: "(\\\")"
+        beginCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+        patterns: [
+          {
+            include: "#string_double__1"
+          }
+        ]
+        end: "(\\\")"
+        endCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+      }
+    ]
+  string_double__1:
+    patterns: [
+      {
+        include: "#string_inner"
+      }
+    ]
+  string_double_triple:
+    patterns: [
+      {
+        begin: "(\\\"{3})"
+        beginCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+        patterns: [
+          {
+            include: "#string_double_triple__1"
+          }
+        ]
+        end: "(\\\"{3})"
+        endCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+      }
+    ]
+  string_double_triple__1:
+    patterns: [
+      {
+        include: "#string_inner"
+      }
+    ]
+  string_inner:
+    patterns: [
+      {
+        match: "(\\\\{)"
+        name: "storage.type.string.Storyscript"
+      }
+      {
+        include: "#placeholder"
+      }
+      {
+        begin: "((?!\\{))"
+        beginCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+        contentName: "storage.type.string.Storyscript"
+        end: "(.(?!=\\{))"
+        endCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+      }
+    ]
+  string_inner__1:
+    patterns: []
+  string_single:
+    patterns: [
+      {
+        begin: "(\\')"
+        beginCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+        patterns: [
+          {
+            include: "#string_single__1"
+          }
+        ]
+        end: "(\\')"
+        endCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+      }
+    ]
+  string_single__1:
+    patterns: [
+      {
+        include: "#string_inner"
+      }
+    ]
+  string_single_triple:
+    patterns: [
+      {
+        begin: "(\\'{3})"
+        beginCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+        patterns: [
+          {
+            include: "#string_single_triple__1"
+          }
+        ]
+        end: "(\\'{3})"
+        endCaptures:
+          "1":
+            name: "storage.type.string.Storyscript"
+      }
+    ]
+  string_single_triple__1:
+    patterns: [
+      {
+        include: "#string_inner"
+      }
+    ]
+  type:
+    patterns: [
+      {
+        match: "(int|string|boolean|map|list|object)"
+        name: "support.type.Storyscript"
+      }
+    ]
+  varattr:
+    patterns: [
+      {
+        match: "(\\.[\\w_]+)"
+        name: "meta.identifier.Storyscript"
+      }
+    ]
+  variable:
+    patterns: [
+      {
+        match: "([\\w_]+)"
+        name: "meta.identifier.Storyscript"
+      }
+    ]

--- a/grammars/update.js
+++ b/grammars/update.js
@@ -1,0 +1,24 @@
+#!/usr/bin/env node
+
+// Updates the storysript CSON file from the submodule
+
+const CSON = require('cson');
+const fs = require('fs');
+const path = require('path');
+
+const root_dir = path.join(__dirname, '..');
+
+const grammar = path.join(root_dir, 'syntax-highlighter/dist/atom/grammars/storyscript.cson');
+const grammarJSON = path.join(root_dir, 'grammars', 'storyscript.cson');
+
+console.log(`Reading: ${grammar}`);
+
+const input = fs.readFileSync(grammar, 'utf8');
+const result = CSON.parse(input);
+
+// fixup the scopeName
+result.scopeName = 'source.story';
+
+console.log(`Writing: ${grammarJSON}`);
+const text = CSON.stringify(result, null, 2);
+fs.writeFileSync(grammarJSON, text);

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "ide-storyscript",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -188,6 +188,12 @@
           }
         }
       }
+    },
+    "typescript": {
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.4.1.tgz",
+      "integrity": "sha512-3NSMb2VzDQm8oBTLH6Nj55VVtUEpe/rgkIzMir0qVoLyjDZlnMBva0U6vDiV3IH+sl/Yu6oP5QwsAQtHPmDd2Q==",
+      "dev": true
     },
     "vscode-jsonrpc": {
       "version": "4.0.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -126,6 +126,11 @@
       "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
       "dev": true
     },
+    "lodash": {
+      "version": "4.17.11",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.11.tgz",
+      "integrity": "sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg=="
+    },
     "requirefresh": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-2.2.0.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,9 +1,32 @@
 {
   "name": "ide-storyscript",
-  "version": "0.0.0",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@types/atom": {
+      "version": "1.31.1",
+      "resolved": "https://registry.npmjs.org/@types/atom/-/atom-1.31.1.tgz",
+      "integrity": "sha512-359WfFUWltkUszDjb3SfCmdKXHqXxn2oTn+lGYE0cRfDtVVdYKDXxKoJVThTY2KWNHQ/w1KXL4lTxvFYK0CP5w==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      },
+      "dependencies": {
+        "@types/node": {
+          "version": "11.13.0",
+          "resolved": "https://registry.npmjs.org/@types/node/-/node-11.13.0.tgz",
+          "integrity": "sha512-rx29MMkRdVmzunmiA4lzBYJNnXsW/PhG4kMBy2ATsYaDjGGR75dCFEVVROKpNwlVdcUX3xxlghKQOeDPBJobng==",
+          "dev": true
+        }
+      }
+    },
+    "@types/node": {
+      "version": "8.10.45",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-8.10.45.tgz",
+      "integrity": "sha512-tGVTbA+i3qfXsLbq9rEq/hezaHY55QxQLeXQL2ejNgFAxxrgu8eMmYIOsRcl7hN1uTLVsKOOYacV/rcJM3sfgQ==",
+      "dev": true
+    },
     "atom-languageclient": {
       "version": "0.9.9",
       "resolved": "https://registry.npmjs.org/atom-languageclient/-/atom-languageclient-0.9.9.tgz",
@@ -15,10 +38,151 @@
         "vscode-languageserver-types": "3.12.0"
       }
     },
+    "coffee-script": {
+      "version": "1.12.7",
+      "resolved": "https://registry.npmjs.org/coffee-script/-/coffee-script-1.12.7.tgz",
+      "integrity": "sha512-fLeEhqwymYat/MpTPUjSKHVYYl0ec2mOyALEMLmzr5i1isuG+6jfI2j2d5oBO3VIzgUXgBVIcOT9uH1TFxBckw==",
+      "dev": true
+    },
+    "cson": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/cson/-/cson-5.1.0.tgz",
+      "integrity": "sha512-hh97pBcNEc24OQn+CBYu1pp9kcEqp3dE0oO52QIoQkDREnZYHUD1YcKcGvHU+k9lgCmIXHslJfGTie58zjhLnA==",
+      "dev": true,
+      "requires": {
+        "coffee-script": "^1.12.7",
+        "cson-parser": "^1.3.4",
+        "editions": "^1.3.3",
+        "extract-opts": "^3.3.1",
+        "requirefresh": "^2.1.0",
+        "safefs": "^4.1.0"
+      }
+    },
+    "cson-parser": {
+      "version": "1.3.5",
+      "resolved": "https://registry.npmjs.org/cson-parser/-/cson-parser-1.3.5.tgz",
+      "integrity": "sha1-fsZ14DkUVTO/KmqFYHPxWZ2cLSQ=",
+      "dev": true,
+      "requires": {
+        "coffee-script": "^1.10.0"
+      }
+    },
+    "eachr": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/eachr/-/eachr-3.2.0.tgz",
+      "integrity": "sha1-LDXkPqCGUW95l8+At6pk1VpKRIQ=",
+      "dev": true,
+      "requires": {
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      }
+    },
+    "editions": {
+      "version": "1.3.4",
+      "resolved": "https://registry.npmjs.org/editions/-/editions-1.3.4.tgz",
+      "integrity": "sha512-gzao+mxnYDzIysXKMQi/+M1mjy/rjestjg6OPoYTtI+3Izp23oiGZitsl9lPDPiTGXbcSIk1iJWhliSaglxnUg==",
+      "dev": true
+    },
+    "errlop": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/errlop/-/errlop-1.1.1.tgz",
+      "integrity": "sha512-WX7QjiPHhsny7/PQvrhS5VMizXXKoKCS3udaBp8gjlARdbn+XmK300eKBAAN0hGyRaTCtRpOaxK+xFVPUJ3zkw==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.1.2"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.1.1",
+            "semver": "^5.6.0"
+          }
+        }
+      }
+    },
+    "extract-opts": {
+      "version": "3.3.1",
+      "resolved": "https://registry.npmjs.org/extract-opts/-/extract-opts-3.3.1.tgz",
+      "integrity": "sha1-WrvtyYwNUgLjJ4cn+Rktfghsa+E=",
+      "dev": true,
+      "requires": {
+        "eachr": "^3.2.0",
+        "editions": "^1.1.1",
+        "typechecker": "^4.3.0"
+      }
+    },
     "fuzzaldrin-plus": {
       "version": "0.6.0",
       "resolved": "https://registry.npmjs.org/fuzzaldrin-plus/-/fuzzaldrin-plus-0.6.0.tgz",
       "integrity": "sha1-gy9kifvodnaUWVmckUpnDsIpR+4="
+    },
+    "graceful-fs": {
+      "version": "4.1.15",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.1.15.tgz",
+      "integrity": "sha512-6uHUhOPEBgQ24HM+r6b/QwWfZq+yiFcipKFrOFiBEnWdy5sdzYoi+pJeQaPI5qOLRFqWmAXUPQNsielzdLoecA==",
+      "dev": true
+    },
+    "requirefresh": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/requirefresh/-/requirefresh-2.2.0.tgz",
+      "integrity": "sha512-gXQWrZkXNZZ6qVEh6PQvoASxLY3r6AR4jH8fFjZ+BfPJpDV6RTI82J4A3tkAn2wikU7rxfzU3sIPj94zEV6xPA==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.1.3"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.1.1",
+            "semver": "^5.6.0"
+          }
+        }
+      }
+    },
+    "safefs": {
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/safefs/-/safefs-4.1.0.tgz",
+      "integrity": "sha1-+CrrS9165R9lPrIPZyizBYyNZEU=",
+      "dev": true,
+      "requires": {
+        "editions": "^1.1.1",
+        "graceful-fs": "^4.1.4"
+      }
+    },
+    "semver": {
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-5.7.0.tgz",
+      "integrity": "sha512-Ya52jSX2u7QKghxeoFGpLwCtGlt7j0oY9DYb5apt9nPlJ42ID+ulTXESnt/qAQcoSERyZ5sl3LDIOw0nAn/5DA==",
+      "dev": true
+    },
+    "typechecker": {
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/typechecker/-/typechecker-4.7.0.tgz",
+      "integrity": "sha512-4LHc1KMNJ6NDGO+dSM/yNfZQRtp8NN7psYrPHUblD62Dvkwsp3VShsbM78kOgpcmMkRTgvwdKOTjctS+uMllgQ==",
+      "dev": true,
+      "requires": {
+        "editions": "^2.1.0"
+      },
+      "dependencies": {
+        "editions": {
+          "version": "2.1.3",
+          "resolved": "https://registry.npmjs.org/editions/-/editions-2.1.3.tgz",
+          "integrity": "sha512-xDZyVm0A4nLgMNWVVLJvcwMjI80ShiH/27RyLiCnW1L273TcJIA25C4pwJ33AWV01OX6UriP35Xu+lH4S7HWQw==",
+          "dev": true,
+          "requires": {
+            "errlop": "^1.1.1",
+            "semver": "^5.6.0"
+          }
+        }
+      }
     },
     "vscode-jsonrpc": {
       "version": "4.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ide-storyscript",
   "main": "./out/storyscript.js",
-  "version": "0.0.1",
+  "version": "0.0.0",
   "description": "Storyscript support",
   "keywords": [
     "storyscript",
@@ -81,7 +81,8 @@
     }
   },
   "dependencies": {
-    "atom-languageclient": "^0.9.9"
+    "atom-languageclient": "^0.9.9",
+    "lodash": "^4.17.11"
   },
   "devDependencies": {
     "@types/atom": "^1.31.1",

--- a/package.json
+++ b/package.json
@@ -87,7 +87,8 @@
   "devDependencies": {
     "@types/atom": "^1.31.1",
     "@types/node": "^8.0.0",
-    "cson": "^5.1.0"
+    "cson": "^5.1.0",
+    "typescript": "^3.4.1"
   },
   "package-deps": [
     "atom-ide-ui:^0.5.3"

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "ide-storyscript",
-  "main": "./lib/storyscript",
-  "version": "0.0.0",
+  "main": "./out/storyscript.js",
+  "version": "0.0.1",
   "description": "Storyscript support",
   "keywords": [
     "storyscript",
@@ -82,5 +82,13 @@
   },
   "dependencies": {
     "atom-languageclient": "^0.9.9"
-  }
+  },
+  "devDependencies": {
+    "@types/atom": "^1.31.1",
+    "@types/node": "^8.0.0",
+    "cson": "^5.1.0"
+  },
+  "package-deps": [
+    "atom-ide-ui:^0.5.3"
+  ]
 }

--- a/src/bootstrap/index.ts
+++ b/src/bootstrap/index.ts
@@ -1,0 +1,196 @@
+import * as path from 'path';
+import * as fs from 'fs';
+import {
+    exec as childExec
+} from 'child_process';
+import {
+    promisify
+} from 'util';
+
+import {
+    some
+} from 'lodash';
+
+import { expectedSLSVersion } from './sls';
+
+function log(msg:string) {
+    console.log("[sls] ", msg);
+}
+
+const stat = promisify(fs.stat);
+
+// run a command asynchronously
+function execAsync(cmd, options: object = {}): Promise<string> {
+  return new Promise((resolve, reject) => {
+    childExec(cmd, options, (error, stdout, stderr) => {
+       if (error) return reject(error);
+       // for now, we aren't interested in stderr
+       //if (stderr) return resolve(stderr);
+       resolve(stdout);
+    });
+  });
+}
+
+/*
+* Convert a promise into a Go-style plain promise:
+*
+* ```
+* let [err, output] = await plain(myPromise);
+* ```
+*/
+function plain<T>(promise: Promise<T>) : Promise<any[]> {
+    return promise
+        .then(d => [undefined, d])
+        .catch(e => [e, undefined]);
+}
+
+// allow execution with plain-promises
+function exec(cmd: string, options: object = {}){
+    return plain(execAsync(cmd, options));
+}
+
+// Makes sure that an exact version of SLS is installed
+export async function bootstrap(extensionDirectory:string) {
+    const venvFolder = path.join(extensionDirectory, 'venv');
+    const slsBin = path.join(venvFolder, 'bin', 'sls');
+    const progress = new Progress();
+
+    // check the version of the installed SLS binary
+    const [err, output] = await exec(`${slsBin} --version`);
+    if (err) {
+        // Version checking failed. we don't know why, but now it's a good idea
+        // to run the upgrade setup
+        log(`[bootstrap] ERROR: ${err}`);
+        return await upgradeSLS(venvFolder, progress);
+    }
+    const slsVersion = output.trim();
+    if (slsVersion !== expectedSLSVersion) {
+        log(`[bootstrap] Version mismatch: ${slsVersion}, expected: ${expectedSLSVersion}`);
+        return await upgradeSLS(venvFolder, progress);
+    }
+    return slsBin;
+}
+
+class Progress {
+    report({message}: {message: string}) {
+        log(message);
+    }
+}
+
+// Trigger the upgrade operation with a progress window
+async function upgradeSLS(venvFolder:string, progress: Progress) {
+    const upgrader = new SLSUpgrade(venvFolder, progress);
+    return await upgrader.run();
+}
+
+// Custom upgrade error that might be thrown during the SLS upgrade process
+class SLSUpgradeError extends Error {
+    constructor(message:string) {
+        super(message);
+        Object.setPrototypeOf(this, SLSUpgradeError.prototype);
+        this.name = this.constructor.name;
+    }
+}
+
+/**
+* Create or upgrade a SLS installation.
+*/
+class SLSUpgrade {
+    slsBin:string;
+    venvFolder:string;
+    progress: Progress;
+
+    constructor(venvFolder:string, progress: Progress) {
+        this.venvFolder = venvFolder;
+        this.progress = progress;
+        this.slsBin = undefined;
+    }
+
+    /**
+    * Runs the entire upgrade process step by step.
+    * Aborts if a single step fails.
+    */
+    async run() {
+        this.report("Starting bootstrapping");
+        const steps = [
+            {
+                method: 'checkPython',
+                message: 'Checking Python installation',
+                error: 'No Python3 installation found',
+            },
+            {
+                method: 'createVenv',
+                message: 'Creating virtualenv',
+            },
+            {
+                method: 'installSLS',
+                message: `Installing SLS(${expectedSLSVersion})`,
+            },
+        ];
+        for(let i=0; i < steps.length; i++) {
+            const step = steps[i];
+            try {
+                this.report(step.message);
+                await this[step.method]();
+            } catch(err) {
+                let errorMessage;
+                if (err instanceof SLSUpgradeError) {
+                    errorMessage = err.message;
+                } else if (step.error !== undefined) {
+                    errorMessage = step.error;
+                } else {
+                    // fallback error message
+                    errorMessage = `${step.message} failed`;
+                }
+                this.info(`ERROR in ${step.method}: ${err}`);
+                //Window.showErrorMessage(errorMessage);
+                return false;
+            }
+        }
+        this.report("Bootstrapping succeeded");
+        this.info(`Success -> ${this.slsBin}`);
+        return this.slsBin;
+    }
+
+    // Ensures that python3.6 or higher is available
+    async checkPython() {
+        const output = await execAsync('python3 --version');
+        const pythonVersion = output.replace("Python ", "").trim();
+        const isOldPython = some(["3.0", "3.1", "3.2", "3.3", "3.4", "3.5"],
+            e => pythonVersion.startsWith(e)
+        );
+        if (isOldPython) {
+            throw new SLSUpgradeError('SLS requires Python3.6 or newer');
+        }
+    }
+
+    // Ensures a virtualenv directory exists. Otherwise creates a new one
+    async createVenv() {
+        this.info(`Setting up virtualenv in ${this.venvFolder}`);
+        const [err, _] = await plain(stat(this.venvFolder))
+        if (!err) {
+            this.info('Re-using existing virtualenv');
+            return;
+        }
+        await execAsync(`virtualenv --python=python3 ${this.venvFolder}`);
+    }
+
+    // Installs an explicit version of SLS with pip
+    async installSLS() {
+        const pipBin = path.join(this.venvFolder, 'bin', 'pip');
+        await execAsync(`${pipBin} install -U sls==${expectedSLSVersion}`);
+        this.slsBin = path.join(this.venvFolder, 'bin', 'sls');
+    }
+
+    // Reports the current progress to the progress window
+    report(message:string) {
+        this.progress.report({
+            message,
+        });
+    }
+
+    // Logs messages with a [bootstrap] prefix
+    info(message:string) {
+        log(`[bootstrap] ${message}`);
+    }
+}

--- a/src/bootstrap/sls.ts
+++ b/src/bootstrap/sls.ts
@@ -1,0 +1,2 @@
+// the bundled SLS version
+export const expectedSLSVersion = '0.0.4';

--- a/src/storyscript.ts
+++ b/src/storyscript.ts
@@ -1,13 +1,23 @@
-const cp = require('child_process');
-const path = require('path');
-const {AutoLanguageClient} = require('atom-languageclient')
+import * as cp from 'child_process';
+import * as path from 'path';
+import * as net from 'net';
+import {
+    AutoLanguageClient,
+    ConnectionType,
+    LanguageServerProcess
+} from 'atom-languageclient';
 
 class StoryscriptLanguageClient extends AutoLanguageClient {
-  getGrammarScopes () { return [ 'source.story' ] }
-  getLanguageName () { return 'Storyscript' }
-  getServerName () { return 'SLS' }
+  getGrammarScopes(): string[] { return [ 'source.story' ] }
+  getLanguageName(): string { return 'Storyscript' }
+  getServerName(): string { return 'SLS' }
 
-  startServerProcess () {
+  public activate(): void {
+    super.activate();
+    console.log("activated");
+  }
+
+  startServerProcess(): LanguageServerProcess | Promise<LanguageServerProcess> {
     const connectionType = this.getConnectionType();
     if (connectionType == 'stdio') {
       return this.spawnServer(['--stdio']);
@@ -16,12 +26,11 @@ class StoryscriptLanguageClient extends AutoLanguageClient {
     }
   }
 
-  spawnServer(args) {
+  spawnServer(args) : LanguageServerProcess {
     const slsBin = 'sls';
     const serverHome = path.join(__dirname, '..');
     this.logger.debug(`starting "${slsBin} ${args.join(' ')}"`)
     const childProcess = cp.spawn(slsBin, args, { cwd: serverHome })
-    this.captureServerErrors(childProcess)
     childProcess.on('exit', exitCode => {
       if (exitCode != 0 && exitCode != null) {
         atom.notifications.addError('IDE-Storyscript language server stopped unexpectedly.', {
@@ -33,7 +42,7 @@ class StoryscriptLanguageClient extends AutoLanguageClient {
     return childProcess;
   }
 
-  spawnServerWithSocket () {
+  spawnServerSocket(): Promise<LanguageServerProcess> {
     return new Promise((resolve, reject) => {
       let childProcess
       const server = net.createServer(socket => {
@@ -47,7 +56,7 @@ class StoryscriptLanguageClient extends AutoLanguageClient {
     })
   }
 
-  getConnectionType() {
+  getConnectionType() : ConnectionType {
     const connectionType = atom.config.get('ide-storyscript.connectionType');
     switch (connectionType) {
       case 'auto':    return process.platform === 'win32' ? 'socket' : 'stdio';
@@ -68,4 +77,6 @@ class StoryscriptLanguageClient extends AutoLanguageClient {
 
 }
 
-module.exports = new StoryscriptLanguageClient();
+console.log("fo2");
+const client = new StoryscriptLanguageClient();
+export = client;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,12 @@
+{
+	"compilerOptions": {
+		"module": "commonjs",
+		"target": "es6",
+		"outDir": "out",
+		"rootDir": "src",
+		"lib": ["es6", "dom"],
+		"sourceMap": true
+	},
+	"include": ["src"],
+	"exclude": ["node_modules", ".vscode-test"]
+}


### PR DESCRIPTION
Makes the Atom plugin usable and on par with the VSCode plugin. If the bootstrapping gets more complicated, we should probably separate this into its own package.